### PR TITLE
Retake test

### DIFF
--- a/src/features/homePage/HomePage.tsx
+++ b/src/features/homePage/HomePage.tsx
@@ -15,38 +15,37 @@ export const HomePage = () => {
     <Shell>
       <Container className={styles.container}>
         <Grid>
-          {featureTiles.map(({ title, Icon, link, description, disabled }) => (
-            <Tooltip label={`${title} Coming Soon`} key={title} disabled={!disabled}>
-              <Grid.Col>
-                <Paper
-                  onClick={() => !disabled && history.push(link)}
-                  withBorder
-                  p="md"
-                  h={150}
-                  w="100%"
-                  display="flex"
-                  className={classNames(
-                    commonStyles.lightNavyBg,
-                    commonStyles.hoverItem,
-                    commonStyles.navTile,
-                    {
-                      [commonStyles.disabled]: disabled,
-                    },
-                  )}
-                >
-                  <Group className={styles.left}>
-                    <Icon className={styles.icon} stroke={1} />
-                  </Group>
-                  <Group className={styles.right}>
-                    <Text fw="bold" size="xl" ta="left">
-                      {title}
-                    </Text>
-                    <Text>{description}</Text>
-                  </Group>
-                </Paper>
-              </Grid.Col>
-            </Tooltip>
-          ))}
+          {featureTiles
+            .filter(({ disabled }) => !disabled)
+            .map(({ title, Icon, link, description }) => (
+              <Tooltip label={`${title} Coming Soon`} key={title}>
+                <Grid.Col>
+                  <Paper
+                    onClick={() => history.push(link)}
+                    withBorder
+                    p="md"
+                    h={150}
+                    w="100%"
+                    display="flex"
+                    className={classNames(
+                      commonStyles.lightNavyBg,
+                      commonStyles.hoverItem,
+                      commonStyles.navTile,
+                    )}
+                  >
+                    <Group className={styles.left}>
+                      <Icon className={styles.icon} stroke={1} />
+                    </Group>
+                    <Group className={styles.right}>
+                      <Text fw="bold" size="xl" ta="left">
+                        {title}
+                      </Text>
+                      <Text>{description}</Text>
+                    </Group>
+                  </Paper>
+                </Grid.Col>
+              </Tooltip>
+            ))}
         </Grid>
       </Container>
     </Shell>

--- a/src/shared/components/pageHeader/NavigationCenter.tsx
+++ b/src/shared/components/pageHeader/NavigationCenter.tsx
@@ -43,32 +43,31 @@ export const NavigationCenter = () => {
       >
         <Container>
           <Grid py="sm">
-            {featureTiles.map(({ title, Icon, disabled, link }) => (
-              <Grid.Col span={6} key={title} className={styles.navCenter}>
-                <Paper
-                  onClick={() => !disabled && history.push(link)}
-                  withBorder
-                  p="md"
-                  h={150}
-                  w="100%"
-                  radius="xm"
-                  display="flex"
-                  className={classNames(
-                    commonStyles.lightNavyBg,
-                    commonStyles.hoverItem,
-                    commonStyles.navTile,
-                    {
-                      [commonStyles.disabled]: disabled,
-                    },
-                  )}
-                >
-                  <div>
-                    <Icon size={isMobile ? 70 : 100} />
-                    <Text size="sm">{title}</Text>
-                  </div>
-                </Paper>
-              </Grid.Col>
-            ))}
+            {featureTiles
+              .filter(({ disabled }) => !disabled)
+              .map(({ title, Icon, link }) => (
+                <Grid.Col span={6} key={title} className={styles.navCenter}>
+                  <Paper
+                    onClick={() => history.push(link)}
+                    withBorder
+                    p="md"
+                    h={150}
+                    w="100%"
+                    radius="xm"
+                    display="flex"
+                    className={classNames(
+                      commonStyles.lightNavyBg,
+                      commonStyles.hoverItem,
+                      commonStyles.navTile,
+                    )}
+                  >
+                    <div>
+                      <Icon size={isMobile ? 70 : 100} />
+                      <Text size="sm">{title}</Text>
+                    </div>
+                  </Paper>
+                </Grid.Col>
+              ))}
           </Grid>
         </Container>
       </Modal>

--- a/src/shared/config/featureConstants.ts
+++ b/src/shared/config/featureConstants.ts
@@ -1,6 +1,7 @@
 import {
   IconCertificate,
   IconChecklist,
+  IconReportSearch,
   IconUsersGroup,
   IconWorldSearch,
   TablerIconsProps,
@@ -17,6 +18,12 @@ export type FeatureTile = {
 };
 
 export const featureTiles: FeatureTile[] = [
+  {
+    title: 'Career Paths',
+    description: 'View your career path results and re-take the test',
+    Icon: IconReportSearch,
+    link: urls.careersTest,
+  },
   {
     title: 'Industry Insights',
     description: 'Explore industry insights and discover the potential of your careers',

--- a/src/shared/hooks/useCareerTestStorage.ts
+++ b/src/shared/hooks/useCareerTestStorage.ts
@@ -36,9 +36,16 @@ export const useCareerTestStorage = () => {
     localStorage.setItem(baseKey, JSON.stringify(initialStoredValues));
   };
 
+  const setupFormValues = ({ profile, careerPaths }: UserProfile) => {
+    storeTestValues({ key: 'formValues', value: profile });
+    storeTestValues({ key: 'careerPaths', value: careerPaths });
+    storeTestValues({ key: 'step', value: CareerStep.COMPLETE });
+  };
+
   return {
     resetValues,
     storeTestValues,
+    setupFormValues,
     careerTestStorage: getValues(),
   };
 };


### PR DESCRIPTION
Allows user to retake test and save the new results
- on save, will associate the newly created profile with the existing profile
- save only enabled if there is data to associate

Updates the tiles
- removes cv builder and mentor network
- adds career path test to tiles

<img width="1440" alt="Screenshot 2023-12-02 at 22 19 47" src="https://github.com/Career26/frontend/assets/98622246/0ad7a13e-ae1a-47dd-9062-37d44dfe7640">
<img width="1440" alt="Screenshot 2023-12-02 at 22 19 58" src="https://github.com/Career26/frontend/assets/98622246/032f8885-dfd3-42b2-9238-239b22857a52">
<img width="1440" alt="Screenshot 2023-12-02 at 22 20 52" src="https://github.com/Career26/frontend/assets/98622246/555b1f06-4b85-4f46-a528-c4b532d03019">
